### PR TITLE
Fix Maplesoft branding.

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 This package provides Emacs modes for developing Maple code.
-Maple is computer algebra system sold by Maplesoft Inc.
+Maple is computer algebra system sold by [Waterloo Maple Inc.](http://www.maplesoft.com).
 
 The major modes are
 


### PR DESCRIPTION
There is no "Maplesoft inc.", the company is "Waterloo Maple Inc."
